### PR TITLE
Replace `methods_getter!` and `handler!` macros with newtypes

### DIFF
--- a/src/appnodes.rs
+++ b/src/appnodes.rs
@@ -1,5 +1,5 @@
 use crate::devicenode::METH_PING;
-use crate::client::{Route, ClientCommand, Sender};
+use crate::client::{ClientCommand, RequestHandler, Route, Sender};
 use log::error;
 use shv::metamethod::{AccessLevel, Flag, MetaMethod};
 use shv::{RpcMessageMetaTags, RpcValue, RpcMessage};
@@ -84,7 +84,7 @@ pub fn app_node_routes<S>() -> Vec<Route<S>> {
             METH_NAME,
             METH_PING,
         ],
-        crate::handler_stateless!(app_node_process_request),
+        RequestHandler::stateless(app_node_process_request),
     )]
     .into()
 }
@@ -152,7 +152,7 @@ async fn app_device_node_process_request(request: RpcMessage, client_cmd_tx: Sen
 pub fn app_device_node_routes<T>() -> Vec<Route<T>> {
     [Route::new(
         [METH_NAME, METH_VERSION, METH_SERIAL_NUMBER],
-        crate::handler_stateless!(app_device_node_process_request),
+        RequestHandler::stateless(app_device_node_process_request),
     )]
     .into()
 }

--- a/src/examples/simple_device_tokio.rs
+++ b/src/examples/simple_device_tokio.rs
@@ -11,7 +11,7 @@ use shv::{RpcMessage, RpcMessageMetaTags};
 use shvclient::appnodes::{
     app_device_node_routes, app_node_routes, APP_DEVICE_METHODS, APP_METHODS,
 };
-use shvclient::SIG_CHNG;
+use shvclient::{MethodsGetter, RequestHandler, SIG_CHNG};
 use shvclient::{ClientCommand, ClientEvent, ClientEventsReceiver, Route, Sender, AppData};
 use simple_logger::SimpleLogger;
 
@@ -116,7 +116,7 @@ async fn delay_node_process_request(
 fn delay_node_routes() -> Vec<Route<State>> {
     [Route::new(
         [METH_GET_DELAYED],
-        shvclient::handler!(delay_node_process_request),
+        RequestHandler::stateful(delay_node_process_request),
     )]
     .into()
 }
@@ -190,8 +190,8 @@ pub(crate) async fn main() -> shv::Result<()> {
         .mount_static(".app/device", &APP_DEVICE_METHODS, app_device_node_routes())
         .mount_static("status/delayed", &DELAY_METHODS, delay_node_routes())
         .mount_dynamic("status/dyn",
-                       shvclient::methods_getter!(dyn_methods_getter),
-                       shvclient::handler_stateless!(dyn_handler))
+                        MethodsGetter::new(dyn_methods_getter),
+                        RequestHandler::stateless(dyn_handler))
         .with_app_data(cnt)
         .run_with_init(&client_config, app_tasks)
         // .run(&client_config)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,8 @@ pub use client::{
     ClientEventsReceiver,
     Route,
     Sender,
+    MethodsGetter,
+    RequestHandler,
 };
 pub use devicenode::{
     METH_GET,


### PR DESCRIPTION
Replaces `MethodsGetter` and `RequestHandler` type aliases with newtypes, allowing the use of constructors instead of using the `methods_getter!`, `handler!`, and `handler_stateless!` macros.